### PR TITLE
Fix ACF bug with image and file fields in repeatable fields returning the previous image or file field data due to filter order.

### DIFF
--- a/network-media-library.php
+++ b/network-media-library.php
@@ -414,7 +414,7 @@ class ACF_Value_Filter {
 	 *
 	 * @var mixed Field value.
 	 */
-	protected $value = null;
+	protected $value = [];
 
 	/**
 	 * Sets up the necessary action and filter callbacks.
@@ -457,7 +457,7 @@ class ACF_Value_Filter {
 			restore_current_blog();
 		}
 
-		$this->value = $image;
+		$this->value[ $field['name'] ] = $image;
 
 		return $image;
 	}
@@ -471,7 +471,7 @@ class ACF_Value_Filter {
 	 * @return mixed The updated value.
 	 */
 	public function filter_acf_attachment_format_value( $value, $post_id, array $field ) {
-		return $this->value;
+		return $this->value[ $field['name'] ];
 	}
 }
 


### PR DESCRIPTION
The problem is that when a repeatable field like Flexible Content or Repeater is used, ACF automatically fetches all subfields at once, causing the `acf/load_value/type={$type}` filter to run on **all** applicable fields before running the `acf/format_value/type={$type}` filter. This causes the `acf/format_value/type={$type}` filter to always use the value from the last field from the `acf/load_value/type={$type}` filter.

The problem can be replicated by creating a ACF repeater field with an image field in it. Adding at least 2 rows with different images. Then loop over them and log or print the value returned by `get_field`.