### PR TITLE
Fix bugs of ACF and featured media

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2017 Frank Bültge
 Copyright (c) 2018 Human Made
+Copyright (c) 2022 Kite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/network-media-library.php
+++ b/network-media-library.php
@@ -414,7 +414,7 @@ class ACF_Value_Filter {
 	 *
 	 * @var mixed Field value.
 	 */
-	protected $value = null;
+	protected $value = [];
 
 	/**
 	 * Sets up the necessary action and filter callbacks.
@@ -457,7 +457,7 @@ class ACF_Value_Filter {
 			restore_current_blog();
 		}
 
-		$this->value = $image;
+		$this->value[ $field['name'] ] = $image;
 
 		return $image;
 	}
@@ -471,7 +471,7 @@ class ACF_Value_Filter {
 	 * @return mixed The updated value.
 	 */
 	public function filter_acf_attachment_format_value( $value, $post_id, array $field ) {
-		return $this->value;
+		return $this->value[ $field['name'] ];
 	}
 }
 

--- a/network-media-library.php
+++ b/network-media-library.php
@@ -225,7 +225,11 @@ add_action( 'parse_request', function() {
 		return;
 	}
 
-	if ( ! function_exists( 'get_current_screen' ) || 'upload' !== get_current_screen()->id ) {
+	if ( ! function_exists( 'get_current_screen' ) || !get_current_screen() ) {
+		return;
+	}
+
+	if('upload' !== get_current_screen()->id){
 		return;
 	}
 

--- a/network-media-library.php
+++ b/network-media-library.php
@@ -225,11 +225,11 @@ add_action( 'parse_request', function() {
 		return;
 	}
 
-	if ( ! function_exists( 'get_current_screen' ) || !get_current_screen() ) {
+	if ( ! function_exists( 'get_current_screen' ) || ! get_current_screen() ) {
 		return;
 	}
 
-	if('upload' !== get_current_screen()->id){
+	if ( 'upload' !== get_current_screen()->id ){
 		return;
 	}
 


### PR DESCRIPTION
This PR fixes the following.

- `wp_make_content_images_responsive()`  is deprecated and the `wp_make_content_images_responsive` hook was removed.
  - Use `wp_filter_content_tags()` and the `wp_filter_content_tags` hook instead.
- Fix ACF bug with repeater fields
  - We are using the wrong hook to get the value. We have to get the value before formatted and overwrite it after formatted via `acf/format_value/type={$type}`.
- Fix bugs of saving featured images via REST API (i.e. Block Editor)
  - We have to use the `rest_pre_insert_{$post_type}` hook to get the featured image ID